### PR TITLE
Implement admin notifications

### DIFF
--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -16,6 +16,7 @@ from bot.keyboards import shop_management, goods_management, categories_manageme
     question_buttons
 from bot.logger_mesh import logger
 from bot.misc import TgConfig
+from bot.utils.admin_notify import notify_admin
 
 
 async def shop_callback_handler(call: CallbackQuery):
@@ -143,6 +144,10 @@ async def process_category_for_add(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f'создал новую категорию "{msg}"')
+    await notify_admin(
+        bot,
+        f"Создана категория: {admin_info.first_name} ({user_id}) -> {msg}"
+    )
 
 
 async def delete_category_callback_handler(call: CallbackQuery):
@@ -181,6 +186,10 @@ async def process_category_for_delete(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f'удалил категорию "{category["name"]}"')
+    await notify_admin(
+        bot,
+        f"Удалена категория: {admin_info.first_name} ({user_id}) -> {category['name']}"
+    )
 
 
 async def update_category_callback_handler(call: CallbackQuery):
@@ -232,6 +241,10 @@ async def check_category_name_for_update(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f'изменил категорию "{old_name}" на "{category}"')
+    await notify_admin(
+        bot,
+        f"Обновлена категория: {admin_info.first_name} ({user_id}) {old_name} -> {category}"
+    )
 
 
 async def goods_settings_menu_callback_handler(call: CallbackQuery):
@@ -387,6 +400,10 @@ async def adding_item(message: Message):
         admin_info = await bot.get_chat(user_id)
         logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                     f'создал новую позицию "{item_name}"')
+        await notify_admin(
+            bot,
+            f"Добавлена позиция: {admin_info.first_name} ({user_id}) -> {item_name}"
+        )
     else:
         value = message.text
         await bot.delete_message(chat_id=message.chat.id,
@@ -410,6 +427,10 @@ async def adding_item(message: Message):
         admin_info = await bot.get_chat(user_id)
         logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                     f'создал новую позицию "{item_name}"')
+        await notify_admin(
+            bot,
+            f"Добавлена позиция: {admin_info.first_name} ({user_id}) -> {item_name}"
+        )
 
 
 async def update_item_amount_callback_handler(call: CallbackQuery):
@@ -480,6 +501,10 @@ async def updating_item_amount(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f'добавил товары к позиции "{item_name}" в количестве {len(values_list)} шт')
+    await notify_admin(
+        bot,
+        f"Добавлено товаров: {admin_info.first_name} ({user_id}) -> {item_name} ({len(values_list)} шт)"
+    )
 
 
 async def update_item_callback_handler(call: CallbackQuery):
@@ -589,6 +614,10 @@ async def update_item_process(call: CallbackQuery):
         admin_info = await bot.get_chat(user_id)
         logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                     f'обновил позицию "{item_old_name}" на "{item_new_name}"')
+        await notify_admin(
+            bot,
+            f"Обновлена позиция: {admin_info.first_name} ({user_id}) {item_old_name} -> {item_new_name}"
+        )
     else:
         if answer[1] == 'make':
             await bot.edit_message_text(chat_id=call.message.chat.id,
@@ -634,6 +663,10 @@ async def update_item_infinity(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f'обновил позицию "{item_old_name}" на "{item_new_name}"')
+    await notify_admin(
+        bot,
+        f"Обновлена позиция: {admin_info.first_name} ({user_id}) {item_old_name} -> {item_new_name}"
+    )
 
 
 async def delete_item_callback_handler(call: CallbackQuery):
@@ -672,6 +705,10 @@ async def delete_str_item(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f'удалил позицию "{msg}"')
+    await notify_admin(
+        bot,
+        f"Удалена позиция: {admin_info.first_name} ({user_id}) -> {msg}"
+    )
 
 
 async def show_bought_item_callback_handler(call: CallbackQuery):

--- a/bot/handlers/admin/user_management_states.py
+++ b/bot/handlers/admin/user_management_states.py
@@ -10,6 +10,7 @@ from bot.misc import TgConfig
 from bot.database.models import Permission
 from bot.handlers.other import get_bot_user_ids
 from bot.logger_mesh import logger
+from bot.utils.admin_notify import notify_admin
 
 
 async def user_callback_handler(call: CallbackQuery):
@@ -122,6 +123,10 @@ async def process_admin_for_purpose(call: CallbackQuery):
         admin_info = await bot.get_chat(user_id)
         logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                     f"назначил пользователя {user_data} ({user_info.first_name}) администратором")
+        await notify_admin(
+            bot,
+            f"Назначен админ: {admin_info.first_name} ({user_id}) -> {user_info.first_name} ({user_data})"
+        )
         return
     await call.answer('Недостаточно прав')
 
@@ -146,6 +151,10 @@ async def process_admin_for_remove(call: CallbackQuery):
         admin_info = await bot.get_chat(user_id)
         logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                     f"отозвал роль администратора у пользователя {user_data} ({user_info.first_name})")
+        await notify_admin(
+            bot,
+            f"Снят админ: {admin_info.first_name} ({user_id}) -> {user_info.first_name} ({user_data})"
+        )
         return
     await call.answer('Недостаточно прав')
 
@@ -188,6 +197,10 @@ async def process_replenish_user_balance(message: Message):
     admin_info = await bot.get_chat(user_id)
     logger.info(f"Пользователь {user_id} ({admin_info.first_name}) "
                 f"пополнил баланс пользователя {user_data} ({user_info.first_name}) на {msg}$")
+    await notify_admin(
+        bot,
+        f"Пополнение баланса пользователю: {admin_info.first_name} ({user_id}) -> {user_info.first_name} ({user_data}) {msg}$"
+    )
     try:
         await bot.send_message(chat_id=user_data,
                                text=f'✅ Ваш баланс пополнен на {msg}$',

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -16,6 +16,7 @@ from bot.keyboards import check_sub, main_menu, categories_list, goods_list, \
     profile, rules, user_items_list, back, item_info
 from bot.logger_mesh import logger
 from bot.misc import TgConfig, EnvKeys
+from bot.utils.admin_notify import notify_admin
 from bot.utils.usdltc import get_ltc_usd_price
 from bot.payment.walletgenerator import generate_ltc_wallet
 
@@ -210,6 +211,11 @@ async def buy_item_callback_handler(call: CallbackQuery):
             user_info = await bot.get_chat(user_id)
             logger.info(f"Пользователь {user_id} ({user_info.first_name})"
                         f" купил 1 товар позиции {value_data['item_name']} за {item_price}р")
+            await notify_admin(
+                bot,
+                f"Покупка: {user_info.first_name} ({user_id}) купил {value_data['item_name']}"
+                f" за {item_price}$"
+            )
             return
 
         await bot.edit_message_text(chat_id=call.message.chat.id,

--- a/bot/logger_mesh.py
+++ b/bot/logger_mesh.py
@@ -1,30 +1,35 @@
 import logging
 
+from bot.utils.admin_notify import TelegramLogHandler
 
-def setup_logger():
-    """Настройка основного логгера приложения"""
+
+def setup_logger() -> logging.Logger:
+    """Configure application logger."""
+
     logger = logging.getLogger("bot.logger_mesh")
     logger.setLevel(logging.INFO)
 
-    # Очищаем предыдущие обработчики
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    # Настройка файлового обработчика
-    file_handler = logging.FileHandler("bot.log", encoding="utf-8")
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
+
+    file_handler = logging.FileHandler("bot.log", encoding="utf-8")
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 
-    # Дополнительно: консольный вывод
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
+    telegram_handler = TelegramLogHandler()
+    telegram_handler.setFormatter(formatter)
+    logger.addHandler(telegram_handler)
+
     return logger
 
 
-# Инициализация глобального логгера
 logger = setup_logger()
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -8,6 +8,7 @@ from bot.handlers import register_all_handlers
 from bot.database.models import register_models
 #from bot.logger_mesh import logger, file_handler
 from bot.payment.balance.blnccheker import monitor_ltc_deposits
+from bot.utils.admin_notify import set_telegram_bot
 import asyncio
 
 #logger.addHandler(file_handler)
@@ -19,6 +20,7 @@ async def __on_start_up(dp: Dispatcher) -> None:
     register_models()
 
     bot = dp.bot
+    set_telegram_bot(bot)
     asyncio.create_task(monitor_ltc_deposits(bot))
 
 def start_bot():

--- a/bot/payment/balance/blnccheker.py
+++ b/bot/payment/balance/blnccheker.py
@@ -7,6 +7,7 @@ from bot.utils.usdltc import get_ltc_usd_price
 from bot.utils.LTClogger import is_transaction_logged
 from bot.database.methods import update_balance
 from bot.payment.txlogger import log_transaction
+from bot.utils.admin_notify import notify_admin
 
 
 #Проверяет пополнения всех пользователей
@@ -40,6 +41,11 @@ async def monitor_ltc_deposits(bot):
                         user.telegram_id,
                         f"✅ Пополнение {ltc_amount:.4f} LTC (~${usd_amount})\n"
                         f"Транзакция: https://live.blockcypher.com/ltc/tx/{tx_hash}"
+                    )
+
+                    await notify_admin(
+                        bot,
+                        f"Пополнение баланса: {user.telegram_id} +{usd_amount}$"
                     )
 
         await asyncio.sleep(60)  # Проверка раз в минуту

--- a/bot/utils/admin_notify.py
+++ b/bot/utils/admin_notify.py
@@ -1,0 +1,38 @@
+import asyncio
+import logging
+
+from bot.misc.env import EnvKeys
+
+
+ADMIN_CHAT_ID = EnvKeys.OWNER_ID
+telegram_bot = None
+
+
+def set_telegram_bot(bot) -> None:
+    """Store bot instance for future notifications."""
+    global telegram_bot
+    telegram_bot = bot
+
+
+async def notify_admin(bot, text: str) -> None:
+    """Send a message to the admin chat."""
+    admin_id = ADMIN_CHAT_ID
+    if not admin_id:
+        return
+    try:
+        await bot.send_message(chat_id=int(admin_id), text=text)
+    except Exception as exc:
+        logging.getLogger(__name__).error("Failed to notify admin: %s", exc)
+
+
+class TelegramLogHandler(logging.Handler):
+    """Logging handler that sends ERROR logs to Telegram."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if telegram_bot and ADMIN_CHAT_ID and record.levelno >= logging.ERROR:
+            message = self.format(record)
+            asyncio.create_task(
+                telegram_bot.send_message(int(ADMIN_CHAT_ID), f"⚠️ {message}")
+            )
+
+


### PR DESCRIPTION
## Summary
- create admin notification utilities and telegram log handler
- hook up Telegram log handler in logger setup
- send admin notifications after item management actions
- notify about balance top-ups and item purchases
- set telegram bot for the logger during startup

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6867a070f5f48332a1cab9be111d38f5