### PR TITLE
Improve ENCRYPTION_KEY handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ltc_tg_bot
-a simple free telegram bot, that can be use to sell some products worldwide.
+A simple free Telegram bot that can be used to sell products worldwide.
+
+## Required environment variables
+
+The bot uses symmetric encryption for storing wallet keys. Set the
+`ENCRYPTION_KEY` environment variable before running the application. The value
+must be a base64 encoded key compatible with `cryptography.Fernet`.

--- a/bot/utils/crypters.py
+++ b/bot/utils/crypters.py
@@ -5,9 +5,15 @@ import logging
 logger = logging.getLogger("bot.logger_mesh")
 
 # Инициализация системы шифрования
+ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY")
+
+if ENCRYPTION_KEY is None:
+    raise RuntimeError(
+        "ENCRYPTION_KEY environment variable is required for encryption"
+    )
+
 try:
-    ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY").encode()
-    cipher = Fernet(ENCRYPTION_KEY)
+    cipher = Fernet(ENCRYPTION_KEY.encode())
 except Exception as e:
     logger.critical(f"Ошибка инициализации шифрования: {str(e)}")
     cipher = None

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -1,6 +1,38 @@
 import unittest
 import asyncio
+import os
 from unittest.mock import patch, MagicMock
+import base64
+import secrets
+import sys
+from pathlib import Path
+import types
+
+# Ensure project root is in import path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide dummy aiogram package to satisfy imports
+aiogram = types.ModuleType("aiogram")
+aiogram.utils = types.ModuleType("utils")
+aiogram.utils.executor = types.SimpleNamespace(start_polling=lambda *a, **k: None)
+aiogram.Bot = object
+aiogram.Dispatcher = object
+aiogram.contrib = types.ModuleType("contrib")
+aiogram.contrib.fsm_storage = types.ModuleType("fsm_storage")
+aiogram.contrib.fsm_storage.memory = types.SimpleNamespace(MemoryStorage=object)
+sys.modules.setdefault("aiogram", aiogram)
+sys.modules.setdefault("aiogram.utils", aiogram.utils)
+sys.modules.setdefault("aiogram.utils.executor", aiogram.utils.executor)
+sys.modules.setdefault("aiogram.contrib", aiogram.contrib)
+sys.modules.setdefault("aiogram.contrib.fsm_storage", aiogram.contrib.fsm_storage)
+sys.modules.setdefault(
+    "aiogram.contrib.fsm_storage.memory", aiogram.contrib.fsm_storage.memory
+)
+
+# Ensure encryption key is available before importing application modules
+key = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode()
+os.environ.setdefault("ENCRYPTION_KEY", key)
+
 from bot.database.models import User
 from bot.database.methods.create import create_user  # правильный импорт
 


### PR DESCRIPTION
## Summary
- require ENCRYPTION_KEY on startup
- document the new requirement
- ensure tests set ENCRYPTION_KEY and stub missing modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6867867b79b48332bbee4e3e74f584a6