### PR TITLE
Fix missing commit after deletion

### DIFF
--- a/bot/database/methods/delete.py
+++ b/bot/database/methods/delete.py
@@ -9,6 +9,7 @@ def delete_item(item_name: str) -> None:
 
 def delete_only_items(item_name: str) -> None:
     Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).delete()
+    Database().session.commit()
 
 
 def delete_category(category_name: str) -> None:


### PR DESCRIPTION
## Summary
- ensure changes are committed after `delete_only_items`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_686786423b888332abf314accbd6105c