### PR TITLE
Fix channel URL parsing

### DIFF
--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -66,7 +66,8 @@ async def start(message: Message):
 
     role_data = check_role(user_id)
 
-    chat = TgConfig.CHANNEL_URL[13:]
+    parsed_chat_url = urlparse(TgConfig.CHANNEL_URL)
+    chat = parsed_chat_url.path.lstrip('/')
     try:
         if chat:
             chat_member = await bot.get_chat_member(chat_id=f'@{chat}', user_id=user_id)


### PR DESCRIPTION
## Summary
- parse channel URL with `urlparse` instead of slicing

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb60e6e88332a91917de15dcfc92